### PR TITLE
Fix 'updateLocale' method, Ability to add additional Router's to Nylo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.0] - 2021-09-21
+
+* Fix `updateLocale` method
+* Ability to add additional Router's to Nylo
+
 ## [2.0.1] - 2021-09-18
 
 * Upgrade Dart (v2.14.0)

--- a/lib/localization/app_localization.dart
+++ b/lib/localization/app_localization.dart
@@ -249,9 +249,9 @@ class AppLocale {
   /// Updates the current locale for the app.
   /// Provide the [locale] you wish to use like Locale("es")
   /// The locale needs to also exist within your /lang directory
-  updateLocale(BuildContext context, Locale locale) {
+  updateLocale(BuildContext context, Locale locale) async {
     this.locale = locale;
-    reloadLocale(context, locale);
+    await reloadLocale(context, locale);
   }
 }
 

--- a/lib/nylo.dart
+++ b/lib/nylo.dart
@@ -18,6 +18,23 @@ class Nylo {
     router!.setNyRoutes(plugin.routes());
   }
 
+  /// Allows you to add additional Router's to your project.
+  ///
+  /// file: e.g. /lib/routes/account_router.dart
+  /// NyRouter accountRouter() => nyRoutes((router) {
+  ///    Add your routes here
+  ///    router.route("/account", (context) => AccountPage());
+  ///    router.route("/account/update", (context) => AccountUpdatePage());
+  /// });
+  ///
+  /// Usage in /lib/main.dart e.g. Nylo.addRouter(accountRouter());
+  addRouter(NyRouter router) async {
+    if (this.router == null) {
+      this.router = NyRouter();
+    }
+    this.router!.setRegisteredRoutes(router.getRegisteredRoutes());
+  }
+
   /// Run to init Nylo
   static Future<Nylo> init({required router}) async {
     await dotenv.load(fileName: ".env");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nylo_support
 description: Support library for the Nylo framework. This library supports routing, widgets, localization, cli, storage and more.
-version: 2.0.1
+version: 2.1.0
 homepage: https://nylo.dev
 repository: https://github.com/nylo-core/support
 issue_tracker: https://github.com/nylo-core/support/issues


### PR DESCRIPTION
1. Resolves issues mentioned in #2 
2. New feature to allow multiple routers in Nylo.
Example
file: e.g. new router `/lib/routes/account_router.dart`
``` dart
NyRouter accountRouter() => nyRoutes((router) {
   // Add your routes here
   router.route("/account", (context) => AccountPage());
   router.route("/account/update", (context) => AccountUpdatePage());
});
```
Usage in /lib/main.dart 
e.g. 
```dart
...
void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  Nylo nylo = await Nylo.init(router: buildRouter());

 Nylo.addRouter(accountRouter()); // adds the account routes
```