### PR TITLE
Refactoring the App Localization tool

### DIFF
--- a/lib/localization/app_localization.dart
+++ b/lib/localization/app_localization.dart
@@ -17,7 +17,7 @@ class AppLocalizations {
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();
 
-  late Map<String, String> _localizedStrings;
+  late Map<String, dynamic> _localizedStrings;
 
   /// loads the locale file from the /lang directory
   Future load() async {
@@ -26,14 +26,16 @@ class AppLocalizations {
 
     Map<String, dynamic> jsonMap = json.decode(jsonString);
 
-    _localizedStrings = jsonMap.map((k, v) {
-      return MapEntry(k, v.toString());
-    });
+    _localizedStrings = jsonMap;
   }
 
   /// Translate strings with the [key] used in the .json file.
-  String? trans(String key) {
+  dynamic trans(String key) {
     return _localizedStrings[key];
+  }
+
+  Map<String, dynamic> getLocalizedString() {
+    return _localizedStrings;
   }
 }
 


### PR DESCRIPTION
In this PR, I'm refactoring the way nylo manage the translations.  
Because of dart doesn't populate the stringified json with quotes on the keys and values, we have to store the whole json in the _localizedStrings variable and iterate over the keys to get the plain values. This way we can support deeper keys instead of the actual deep level which one support only one key.

Open to discuss about it.