### PR TITLE
Adding query params support for the router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.3.0] - 2022-07-27
+
+* Merge PR from [youssefKadaouiAbbassi](https://github.com/youssefKadaouiAbbassi) that adds query parameters to the router e.g. "/my-page?hello=world" = {"hello": "world"}
+
 ## [3.2.0] - 2022-06-28
 
 * New optional parameter `inBackpack` added to the `store` when using NyStorage class to also save to your Backpack instance

--- a/lib/controllers/controller.dart
+++ b/lib/controllers/controller.dart
@@ -2,12 +2,16 @@ import 'package:flutter/cupertino.dart';
 import 'package:nylo_support/router/models/ny_argument.dart';
 import 'package:nylo_support/widgets/ny_stateful_widget.dart';
 
+import '../router/models/ny_query_parameters.dart';
+
 /// Base class to handle requests
 class NyRequest {
   String? currentRoute;
   NyArgument? _args;
-  NyRequest({this.currentRoute, NyArgument? args}) {
+  NyQueryParameters? _queryParameters;
+  NyRequest({this.currentRoute, NyArgument? args, NyQueryParameters? queryParameters}) {
     _args = args;
+    _queryParameters = queryParameters;
   }
 
   /// Write [data] to controller
@@ -17,6 +21,9 @@ class NyRequest {
 
   /// Returns data passed as an argument to a route
   dynamic data() => (_args == null ? null : _args!.data);
+
+  /// Returns query params passed to a route
+  dynamic queryParameters() => (_queryParameters == null ? null : _queryParameters!.data);
 }
 
 /// Nylo's base controller class

--- a/lib/controllers/controller.dart
+++ b/lib/controllers/controller.dart
@@ -9,7 +9,10 @@ class NyRequest {
   String? currentRoute;
   NyArgument? _args;
   NyQueryParameters? _queryParameters;
-  NyRequest({this.currentRoute, NyArgument? args, NyQueryParameters? queryParameters}) {
+  NyRequest(
+      {this.currentRoute,
+      NyArgument? args,
+      NyQueryParameters? queryParameters}) {
     _args = args;
     _queryParameters = queryParameters;
   }
@@ -23,7 +26,8 @@ class NyRequest {
   dynamic data() => (_args == null ? null : _args!.data);
 
   /// Returns query params passed to a route
-  dynamic queryParameters() => (_queryParameters == null ? null : _queryParameters!.data);
+  dynamic queryParameters() =>
+      (_queryParameters == null ? null : _queryParameters!.data);
 }
 
 /// Nylo's base controller class
@@ -35,6 +39,11 @@ abstract class BaseController {
 
   /// Returns any data passed through a [Navigator] or [routeTo] method.
   dynamic data() => this.request!.data();
+
+  /// Returns any query parameters passed in a route
+  /// e.g. /my-page?hello=world
+  /// Result {"hello": "world"}
+  dynamic queryParameters() => this.request!.queryParameters();
 
   /// Initialize your controller with this method.
   /// It contains same [BuildContext] as the [NyStatefulWidget].

--- a/lib/router/models/arguments_wrapper.dart
+++ b/lib/router/models/arguments_wrapper.dart
@@ -1,18 +1,26 @@
 import 'package:nylo_support/router/models/base_arguments.dart';
+import 'package:nylo_support/router/models/ny_query_parameters.dart';
 import 'package:page_transition/page_transition.dart';
 
 class ArgumentsWrapper {
   BaseArguments? baseArguments;
+  NyQueryParameters? queryParameters;
   PageTransitionType? pageTransitionType;
   Duration? transitionDuration;
 
   ArgumentsWrapper(
-      {this.baseArguments, this.transitionDuration, this.pageTransitionType});
+      {this.baseArguments,
+      this.queryParameters,
+      this.transitionDuration,
+      this.pageTransitionType});
 
   ArgumentsWrapper copyWith(
-      {BaseArguments? baseArguments, PageTransitionType? pageTransitionType}) {
+      {BaseArguments? baseArguments,
+      NyQueryParameters? queryParameters,
+      PageTransitionType? pageTransitionType}) {
     return ArgumentsWrapper(
         baseArguments: baseArguments ?? this.baseArguments,
+        queryParameters: queryParameters ?? this.queryParameters,
         transitionDuration: transitionDuration ?? this.transitionDuration,
         pageTransitionType: pageTransitionType ?? this.pageTransitionType);
   }
@@ -20,6 +28,8 @@ class ArgumentsWrapper {
   @override
   String toString() {
     return 'ArgumentsWrapper{baseArguments: $baseArguments, '
-        'transitionDuration: $transitionDuration, ';
+        'transitionDuration: $transitionDuration, '
+        'QueryParameters: $queryParameters, '
+        'pageTransitionType: $pageTransitionType}';
   }
 }

--- a/lib/router/models/ny_query_parameters.dart
+++ b/lib/router/models/ny_query_parameters.dart
@@ -1,0 +1,6 @@
+import 'package:nylo_support/router/models/base_arguments.dart';
+
+class NyQueryParameters extends BaseArguments {
+  dynamic data;
+  NyQueryParameters(this.data);
+}

--- a/lib/router/models/nyrouter_route.dart
+++ b/lib/router/models/nyrouter_route.dart
@@ -1,5 +1,6 @@
 import 'package:nylo_support/controllers/controller.dart';
 import 'package:nylo_support/router/models/base_arguments.dart';
+import 'package:nylo_support/router/models/ny_query_parameters.dart';
 import 'package:nylo_support/router/models/nyrouter_route_guard.dart';
 import 'package:nylo_support/router/router.dart';
 import 'package:nylo_support/widgets/ny_stateful_widget.dart';
@@ -11,12 +12,14 @@ import 'ny_argument.dart';
 typedef NyRouterRouteBuilder = Widget Function(
   BuildContext context,
   BaseArguments? args,
+  NyQueryParameters? queryParameters,
 );
 
 class NyRouterRoute {
   final String name;
   late NyRouterRouteBuilder builder;
   final BaseArguments? defaultArgs;
+  final NyQueryParameters? queryParameters;
   final NyRouteView view;
   PageTransitionType pageTransitionType;
 
@@ -29,14 +32,17 @@ class NyRouterRoute {
       {required this.name,
       required this.view,
       this.defaultArgs,
+      this.queryParameters,
       this.routeGuards,
       this.pageTransitionType = PageTransitionType.rightToLeft}) {
-    this.builder = (context, arg) {
+    this.builder = (context, arg, queryParameters) {
       Widget widget = view(context);
       if (widget is NyStatefulWidget) {
         if (widget.controller != null) {
-          widget.controller!.request =
-              NyRequest(currentRoute: name, args: arg as NyArgument?);
+          widget.controller!.request = NyRequest(
+              currentRoute: name,
+              args: arg as NyArgument?,
+              queryParameters: queryParameters);
           widget.controller!.construct(context);
         }
       }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -356,9 +356,20 @@ class NyRouter {
   RouteFactory generator() {
     return (settings) {
       if (settings.name == null) return null;
-      var uriData = Uri.parse(settings.name!);
 
-      final NyRouterRoute? route = _routeNameMappings[uriData.path];
+      Uri? uriSettingName;
+      try {
+        uriSettingName = Uri.parse(settings.name!);
+      } on FormatException catch (e) {
+        NyLogger.error(e.toString());
+      }
+
+      String routeName = settings.name!;
+      if (uriSettingName != null) {
+        routeName = uriSettingName.path;
+      }
+
+      final NyRouterRoute? route = _routeNameMappings[routeName];
 
       if (route == null) return null;
 
@@ -374,11 +385,9 @@ class NyRouter {
         argsWrapper = ArgumentsWrapper();
       }
 
-      if (uriData.queryParameters.isEmpty) {
-        argsWrapper.queryParameters = null;
-      }else {
+      if (uriSettingName != null && uriSettingName.queryParameters.isNotEmpty) {
         argsWrapper.queryParameters =
-            NyQueryParameters(uriData.queryParameters);
+            NyQueryParameters(uriSettingName.queryParameters);
       }
 
       final BaseArguments? baseArgs = argsWrapper.baseArguments;

--- a/lib/widgets/ny_stateful_widget.dart
+++ b/lib/widgets/ny_stateful_widget.dart
@@ -41,4 +41,15 @@ abstract class NyStatefulWidget extends StatefulWidget {
     }
     return this.controller!.request!.data();
   }
+
+  /// Returns query params
+  dynamic queryParams() {
+    if (this.controller == null) {
+      return null;
+    }
+    if (this.controller!.request == null) {
+      return null;
+    }
+    return this.controller!.request!.queryParameters();
+  }
 }

--- a/lib/widgets/ny_stateful_widget.dart
+++ b/lib/widgets/ny_stateful_widget.dart
@@ -43,7 +43,7 @@ abstract class NyStatefulWidget extends StatefulWidget {
   }
 
   /// Returns query params
-  dynamic queryParams() {
+  dynamic queryParameters() {
     if (this.controller == null) {
       return null;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nylo_support
 description: Support library for the Nylo framework. This library supports routing, widgets, localization, cli, storage and more.
-version: 3.2.0
+version: 3.3.0
 homepage: https://nylo.dev
 repository: https://github.com/nylo-core/support
 issue_tracker: https://github.com/nylo-core/support/issues


### PR DESCRIPTION
You can access the query parameters using : widget.queryParams()
if works the same as widget.data()