### PR TITLE
Update sleep() function documentation

### DIFF
--- a/lib/helpers/helper.dart
+++ b/lib/helpers/helper.dart
@@ -452,7 +452,7 @@ dump(dynamic value, {String? tag, bool alwaysPrint = false}) =>
 /// Get the DateTime.now() value.
 DateTime now() => DateTime.now();
 
-/// Sleep for a given amount of milliseconds.
+/// Sleep for a given amount of seconds.
 sleep(int seconds) async {
   await Future.delayed(Duration(seconds: seconds));
 }


### PR DESCRIPTION
changed from milliseconds to seconds a while ago -- this PR updates the docs to match the code.