### PR TITLE
Fixed the state refresh issue in the controller

### DIFF
--- a/lib/controllers/ny_controller.dart
+++ b/lib/controllers/ny_controller.dart
@@ -18,8 +18,14 @@ class NyController extends BaseController {
   }
 
   /// Refreshes the page
+  @Deprecated("Use notifyListeners instead")
   refreshPage() {
     updatePageState("refresh-page", {"setState": () {}});
+  }
+
+  /// Update the state of the page
+  notifyListeners() {
+    updatePageState("set-state", {"setState": () {}});
   }
 
   /// Set the state of the page

--- a/lib/helpers/helper.dart
+++ b/lib/helpers/helper.dart
@@ -372,7 +372,7 @@ void updateState<T>(dynamic name,
 
   String stateName = '';
   if (name is String) {
-    stateName = name;
+    stateName = name.replaceAll("Closure: ", "");
   }
   if (name is RouteView) {
     stateName =

--- a/lib/widgets/ny_base_state.dart
+++ b/lib/widgets/ny_base_state.dart
@@ -238,12 +238,8 @@ abstract class NyBaseState<T extends StatefulWidget> extends State<T> {
       case 'set-state':
         {
           Function()? setStateData = stateData['setState'];
-          if (setStateData != null) {
-            setState(() {
-              setStateData();
-            });
-            return;
-          }
+          if (setStateData != null) setStateData();
+          setState(() {});
         }
       default:
         {}

--- a/lib/widgets/ny_stateful_widget.dart
+++ b/lib/widgets/ny_stateful_widget.dart
@@ -16,8 +16,7 @@ abstract class NyStatefulWidget<T extends BaseController>
   /// Child state
   final dynamic child;
 
-  NyStatefulWidget({super.key, this.child, String? stateName})
-      : state = stateName ?? child.toString() {
+  NyStatefulWidget({super.key, this.child}) : state = child.toString() {
     Nylo nylo = Backpack.instance.nylo();
     controller = nylo.getController(T) ?? NyController();
   }


### PR DESCRIPTION
Performed a replace operation due to incorrect state naming.
Removed the `stateName` parameter from the Stateful Widget due to issues with custom state names.
Added the `notifyListeners` method to align with the conventional state update approach.