### PR TITLE
Networking: Allow all success status code

### DIFF
--- a/lib/networking/ny_base_api_service.dart
+++ b/lib/networking/ny_base_api_service.dart
@@ -156,7 +156,7 @@ class NyBaseApiService {
   /// You can return a different value using this callback.
   handleResponse<T>(Response response,
       {Function(Response response)? handleSuccess}) {
-    bool wasSuccessful = response.statusCode == 200;
+    bool wasSuccessful = response.statusCode >= 200 && response.statusCode < 300;
 
     if (wasSuccessful == true && handleSuccess != null) {
       return handleSuccess(response);


### PR DESCRIPTION
A lot of methods returns 201, 204 upon creating or updating an API item. This would result for handleSuccess to be available even for these.