### PR TITLE
fix: Flutter web support for NyLogger - guard dart:io stdout access with kIsWebFix/web logger support

### DIFF
--- a/lib/helpers/src/ny_logger.dart
+++ b/lib/helpers/src/ny_logger.dart
@@ -229,10 +229,10 @@ class NyLogger {
   }
 
   /// Applies ANSI color to a message based on the log type.
+  /// ANSI colors are not supported on web (dart:io unavailable).
   static String _colorize(String message, String? type) {
-    if (!useColors || !kDebugMode || !stdout.supportsAnsiEscapes) {
-      return message;
-    }
+    if (kIsWeb || !useColors || !kDebugMode) return message;
+    if (!stdout.supportsAnsiEscapes) return message;
     final color = _colors[type];
     if (color == null) return message;
     return '$color$message$_reset';

--- a/lib/helpers/src/ny_logger.dart
+++ b/lib/helpers/src/ny_logger.dart
@@ -230,6 +230,7 @@ class NyLogger {
 
   /// Applies ANSI color to a message based on the log type.
   /// ANSI colors are not supported on web (dart:io unavailable).
+  // test: wasnaker github desktop check
   static String _colorize(String message, String? type) {
     if (kIsWeb || !useColors || !kDebugMode) return message;
     if (!stdout.supportsAnsiEscapes) return message;


### PR DESCRIPTION
## Problem
  
  When running a Nylo app on Flutter web (Chrome), the app crashes during boot
  with the following error:

  Unsupported operation: StdIOUtils._getStdioOutputStream

  **Root cause:** `NyLogger._colorize()` accesses `stdout.supportsAnsiEscapes`
  which requires `dart:io`. On Flutter web, `dart:io` is not available — any
  access to `stdout` throws an unsupported operation error.

  ## Fix

  Added a `kIsWeb` guard before accessing `stdout` in `_colorize()`.
  ANSI terminal colors are not applicable to web environments anyway,
  so returning the plain message on web is the correct behavior.

  ```dart
  // Before
  if (!useColors || !kDebugMode || !stdout.supportsAnsiEscapes) {
    return message;
  }

  // After
  if (kIsWeb || !useColors || !kDebugMode) return message;
  if (!stdout.supportsAnsiEscapes) return message;

  Testing

  Tested with Nylo v7.1.17 on Flutter web (Chrome).
  App boots successfully and renders the home page.

  Impact

  - ✅ Flutter web: now works
  - ✅ Android / iOS / Desktop: no change in behavior
  - ✅ ANSI colors still work on terminal platforms
